### PR TITLE
Fix for django 1.6

### DIFF
--- a/tracking/urls.py
+++ b/tracking/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('tracking.views',
     url(r'^$', 'dashboard', name='tracking-dashboard'),


### PR DESCRIPTION
urls.defaults depricated and no longer works with Django 1.6
