### PR TITLE
Pageview URL truncated by max_length

### DIFF
--- a/tracking/migrations/0007_auto__chg_field_pageview_url.py
+++ b/tracking/migrations/0007_auto__chg_field_pageview_url.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Pageview.url'
+        db.alter_column(u'tracking_pageview', 'url', self.gf('django.db.models.fields.TextField')())
+
+    def backwards(self, orm):
+
+        # Changing field 'Pageview.url'
+        db.alter_column(u'tracking_pageview', 'url', self.gf('django.db.models.fields.CharField')(max_length=500))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'tracking.pageview': {
+            'Meta': {'ordering': "('-view_time',)", 'object_name': 'Pageview'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True'}),
+            'url': ('django.db.models.fields.TextField', [], {}),
+            'view_time': ('django.db.models.fields.DateTimeField', [], {}),
+            'visitor': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pageviews'", 'to': u"orm['tracking.Visitor']"})
+        },
+        u'tracking.visitor': {
+            'Meta': {'ordering': "('-start_time',)", 'object_name': 'Visitor'},
+            'end_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'expiry_age': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'expiry_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'ip_address': ('django.db.models.fields.CharField', [], {'max_length': '39'}),
+            'session_key': ('django.db.models.fields.CharField', [], {'max_length': '40', 'primary_key': 'True'}),
+            'start_time': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'time_on_site': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'visit_history'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'user_agent': ('django.db.models.fields.TextField', [], {'null': 'True'})
+        }
+    }
+
+    complete_apps = ['tracking']

--- a/tracking/models.py
+++ b/tracking/models.py
@@ -69,7 +69,7 @@ class Visitor(models.Model):
 
 class Pageview(models.Model):
     visitor = models.ForeignKey(Visitor, related_name='pageviews')
-    url = models.CharField(max_length=500)
+    url = models.TextField(null=False, editable=False)
     method = models.CharField(max_length=20, null=True)
     view_time = models.DateTimeField()
 


### PR DESCRIPTION
This is pull request is intended to start a discussion about how to fix it.

Currently, the Pageview model's URL field is  `CharField(max_length=500)`

Sites with dynamic content can create quite lengthy URLs. My fork is using `max_length=2000` so that Pageview URLs are browsable. 

However, it seems like arbitrary an max_length will not work as there is no hard spec on how long a URL can be _(http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers)_.

This pull request proposes migrating the field to a TextField. In modern databases like postgresql, there is no performance penalty between `CHAR` and `VARCHAR`(except for space).

> Tip: There are no performance differences between these three types, apart from increased storage size when using the blank-padded type, and a few extra cycles to check the length when storing into a length-constrained column. While character(n) has performance advantages in some other database systems, it has no such advantages in PostgreSQL. In most situations text or character varying should be used instead. _(http://www.postgresql.org/docs/8.3/static/datatype-character.html)_

There is also the possibility of having multiple models with different trade offs - it people care more about space than browsable history, they can choose to use the space saving `max_length=500` model.
I suppose that option could even be disabled or enabled by using this migration or not.
