### PR TITLE
Added supported python3 versions to travis.yml, updated Django versions, removed system_site_packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
     - DJANGO=1.4.13
     - DJANGO=1.5.8
     - DJANGO=1.6.5
-virtualenv:
-    system_site_packages: true
 install:
     - pip install -q Django==$DJANGO --use-mirrors
 script:


### PR DESCRIPTION
- The classifiers for Python 3.2, 3.3, and 3.4 are already in `setup.py`, so I thought it would be nice to include them in testing.
- I updated the Django version numbers used in testing to the latest stable releases, and added Django 1.6 to the mix.
- I removed `system_site_packages: true` because of this issue: https://github.com/travis-ci/travis-ci/issues/2219
