### PR TITLE
Latin Encoding Fix

### DIFF
--- a/tracking/middleware.py
+++ b/tracking/middleware.py
@@ -48,7 +48,7 @@ class VisitorTrackingMiddleware(object):
         except Visitor.DoesNotExist:
             visitor_user_agent = request.META.get('HTTP_USER_AGENT', None)
             if visitor_user_agent is not None:
-                visitor_user_agent = visitor_user_agent.decode('latin-1')
+                visitor_user_agent = visitor_user_agent.decode('latin-1', errors='ignore')
             # Log the ip address. Start time is managed via the
             # field `default` value
             visitor = Visitor(pk=session_key, ip_address=get_ip_address(request),


### PR DESCRIPTION
A user agent that is encoded with latin-1 causes a DataError to be raised when the Visitor objects is saved. The problematic character is a middot.

Error:
DataError: invalid byte sequence for encoding "UTF8": 0xb7

Meta:
'HTTP_USER_AGENT': 'Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; Rogers Hi\xb7Speed Internet; (R1 1.3))', 
