### PR TITLE
Django 1.8 testing and user.id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+sudo: false
+
 python:
     - "2.6"
     - "2.7"
@@ -25,8 +27,10 @@ matrix:
         - python: "3.4"
           env: DJANGO="Django>=1.4,<1.5"
 
-before_install:
-    - sudo apt-get install libgeoip-dev
+addons:
+    apt:
+        packages:
+        - libgeoip-dev
 
 install:
     - pip install -q $DJANGO

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,10 @@ addons:
         - libgeoip-dev
 
 install:
-    - pip install -q $DJANGO
+    - pip install "$DJANGO"
     - pip install geoip
     - pip install coverage django-discover-runner mock unittest2
+    - pip freeze
     - python setup.py develop
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,27 +8,28 @@ python:
     - "3.4"
 
 env:
-    - DJANGO=1.4.16
-    - DJANGO=1.5.11
-    - DJANGO=1.6.8
-    - DJANGO=1.7.1
+    - DJANGO="Django>=1.4,<1.5"
+    - DJANGO="Django>=1.7,<1.8"
+    - DJANGO="Django>=1.8,<1.9"
 
 matrix:
     exclude:
         - python: "2.6"
-          env: DJANGO=1.7.1
+          env: DJANGO="Django>=1.7,<1.8"
+        - python: "2.6"
+          env: DJANGO="Django>=1.8,<1.9"
         - python: "3.2"
-          env: DJANGO=1.4.16
+          env: DJANGO="Django>=1.4,<1.5"
         - python: "3.3"
-          env: DJANGO=1.4.16
+          env: DJANGO="Django>=1.4,<1.5"
         - python: "3.4"
-          env: DJANGO=1.4.16
+          env: DJANGO="Django>=1.4,<1.5"
 
 before_install:
     - sudo apt-get install libgeoip-dev
 
 install:
-    - pip install -q Django==$DJANGO
+    - pip install -q $DJANGO
     - pip install geoip
     - pip install coverage django-discover-runner mock unittest2
     - python setup.py develop

--- a/tracking/middleware.py
+++ b/tracking/middleware.py
@@ -70,7 +70,7 @@ class VisitorTrackingMiddleware(object):
         # the user is object exists. Check using `user_id` to prevent
         # a database hit.
         if user and not visitor.user_id:
-            visitor.user = user
+            visitor.user_id = user.id
 
         # update some session expiration details
         visitor.expiry_age = request.session.get_expiry_age()


### PR DESCRIPTION
This adds Django 1.8 testing, the travis CI container infrastructure and corrects a RuntimeWarning introduced with changes in Django 1.8.

It also drops tests for Django 1.5 and 1.6 since those are no longer officially supported by the Django project.