### PR TITLE
Adding an atomic block around saving/updating visitors

### DIFF
--- a/tracking/middleware.py
+++ b/tracking/middleware.py
@@ -2,7 +2,7 @@ import re
 import logging
 import warnings
 
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 from django.utils.encoding import smart_text
 
@@ -87,15 +87,16 @@ class VisitorTrackingMiddleware(object):
             time_on_site = total_seconds(visit_time - visitor.start_time)
         visitor.time_on_site = int(time_on_site)
 
-        try:
-            visitor.save()
-        except IntegrityError:
-            # there is a small chance a second response has saved this
-            # Visitor already and a second save() at the same time (having
-            # failed to UPDATE anything) will attempt to INSERT the same
-            # session key (pk) again causing an IntegrityError
-            # If this happens we'll just grab the "winner" and use that!
-            visitor = Visitor.objects.get(pk=session_key)
+        with transaction.atomic():
+            try:
+                visitor.save()
+            except IntegrityError:
+                # there is a small chance a second response has saved this
+                # Visitor already and a second save() at the same time (having
+                # failed to UPDATE anything) will attempt to INSERT the same
+                # session key (pk) again causing an IntegrityError
+                # If this happens we'll just grab the "winner" and use that!
+                visitor = Visitor.objects.get(pk=session_key)
 
         return visitor
 


### PR DESCRIPTION
## Purpose
There still seems to be a race condition present in this block. I believe that wrapping the save and exception handling in an atomic block will solve the issues I am seeing.

## Related Issue
https://github.com/bruth/django-tracking2/issues/55 - The issue I submitted. Detailed view of the problem I am facing, with stack trace + context.
#52 - The PR that mentioned there is most likely a race condition around this save, and added exception handling around it.

## Note
The only tests that failed on the Travis build are the Django 1.4 tests. This is no longer a supported version of Django, and I was under the assumption that this library also no longer supported it.