### PR TITLE
Adding atomic save around potential race condition.

### DIFF
--- a/tracking/middleware.py
+++ b/tracking/middleware.py
@@ -2,7 +2,7 @@ import re
 import logging
 import warnings
 
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 from django.utils.encoding import smart_text
 
@@ -88,7 +88,8 @@ class VisitorTrackingMiddleware(object):
         visitor.time_on_site = int(time_on_site)
 
         try:
-            visitor.save()
+            with transaction.atomic():
+                visitor.save()
         except IntegrityError:
             # there is a small chance a second response has saved this
             # Visitor already and a second save() at the same time (having


### PR DESCRIPTION
## Purpose
There still seems to be a race condition present in this block. I believe that wrapping the save and exception handling in an atomic block will solve the issues I am seeing.

## Related Issue
https://github.com/bruth/django-tracking2/issues/55 - The issue I submitted. Detailed view of the problem I am facing, with stack trace + context.
#52 - The PR that mentioned there is most likely a race condition around this save, and added exception handling around it.

## Note
I managed to mess up the rebasing operation for #56, so I have just created this and will close the other.