### PR TITLE
use generic field name for username

### DIFF
--- a/tracking/managers.py
+++ b/tracking/managers.py
@@ -167,7 +167,10 @@ class VisitorManager(CacheManager):
         users = list(get_user_model().objects.filter(**user_kwargs).annotate(
             visit_count=Count('visit_history'),
             time_on_site=Avg('visit_history__time_on_site'),
-        ).filter(visit_count__gt=0).order_by('-time_on_site', 'username'))
+        ).filter(visit_count__gt=0).order_by(
+            '-time_on_site',
+            get_user_model().USERNAME_FIELD,
+        ))
 
         # Aggregate pageviews per visit
         for user in users:


### PR DESCRIPTION
Use the generic username string. Otherwise, tracking page will crash when the user model is customized with a different username field than "username"

https://docs.djangoproject.com/en/2.0/topics/auth/customizing/#django.contrib.auth.models.CustomUser