### PR TITLE
New flag to ignore superuser pageviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ is False
 `TRACK_ANONYMOUS_USERS` - If False, anonymous users will not be tracked.
 Default is True
 
+`TRACK_SUPERUSERS` - If False, users with the superuser flag set to True will
+not be tracked.  Default is True.
+
 `TRACK_PAGEVIEWS` - If True, individual pageviews will be tracked.
 
 `TRACK_IGNORE_URLS` - A list of regular expressions that will be matched
@@ -83,7 +86,7 @@ static serve view or via a lightweight server in production. Read more
 [here](https://docs.djangoproject.com/en/dev/howto/static-files/#serving-other-directories)
 
 `TRACK_IGNORE_STATUS_CODES` - A list of HttpResponse status codes that will be ignored.
-If the HttpResponse object has a `status_code` in this blacklist, the pageview record 
+If the HttpResponse object has a `status_code` in this blacklist, the pageview record
 will not be saved. For example,
 
 ```python

--- a/tracking/middleware.py
+++ b/tracking/middleware.py
@@ -22,6 +22,7 @@ from tracking.settings import (
     TRACK_PAGEVIEWS,
     TRACK_QUERY_STRING,
     TRACK_REFERER,
+    TRACK_SUPERUSERS,
 )
 
 track_ignore_urls = [re.compile(x) for x in TRACK_IGNORE_URLS]
@@ -58,6 +59,10 @@ class VisitorTrackingMiddleware(MiddlewareMixin):
 
         # Do not tracking anonymous users if set
         if user is None and not TRACK_ANONYMOUS_USERS:
+            return False
+
+        # Do not track superusers if set
+        if user and user.is_superuser and not TRACK_SUPERUSERS:
             return False
 
         # Do not track ignored urls

--- a/tracking/settings.py
+++ b/tracking/settings.py
@@ -2,6 +2,7 @@ from django.conf import settings
 
 TRACK_AJAX_REQUESTS = getattr(settings, 'TRACK_AJAX_REQUESTS', False)
 TRACK_ANONYMOUS_USERS = getattr(settings, 'TRACK_ANONYMOUS_USERS', True)
+TRACK_SUPERUSERS = getattr(settings, 'TRACK_SUPERUSERS', True)
 
 TRACK_PAGEVIEWS = getattr(settings, 'TRACK_PAGEVIEWS', False)
 

--- a/tracking/tests/test_middleware.py
+++ b/tracking/tests/test_middleware.py
@@ -97,6 +97,26 @@ class MiddlewareTestCase(TestCase):
         self.assertEqual(Visitor.objects.count(), 0)
         self.assertEqual(Pageview.objects.count(), 0)
 
+    @patch('tracking.middleware.TRACK_SUPERUSERS', True)
+    def test_track_superusers_true(self):
+        auth = {'username': 'me', 'email': 'me@me.com', 'password': 'me'}
+        User.objects.create_superuser(**auth)
+        self.assertTrue(self.client.login(**auth))
+
+        self.client.get('/')
+        self.assertEqual(Visitor.objects.count(), 1)
+        self.assertEqual(Pageview.objects.count(), 1)
+
+    @patch('tracking.middleware.TRACK_SUPERUSERS', False)
+    def test_track_superusers_false(self):
+        auth = {'username': 'me', 'email': 'me@me.com', 'password': 'me'}
+        User.objects.create_superuser(**auth)
+        self.assertTrue(self.client.login(**auth))
+
+        self.client.get('/')
+        self.assertEqual(Visitor.objects.count(), 0)
+        self.assertEqual(Pageview.objects.count(), 0)
+
     def test_track_ignore_url(self):
         ignore_urls = [re.compile('foo')]
         with patch('tracking.middleware.track_ignore_urls', ignore_urls):


### PR DESCRIPTION
This adds a flag to allow django-tracking2 to ignore all pageviews from superusers, so that internal usage doesn't pollute user metrics.